### PR TITLE
Add documentation for `system.get_access_code`

### DIFF
--- a/mqtt.md
+++ b/mqtt.md
@@ -836,6 +836,33 @@ Controls the LEDs of the printer.
 
 See basic structure
 
+## system.get_access_code
+
+Gets the LAN access code of the printer
+
+**Request**
+```json
+{
+		"system": {
+				"sequence_id": "0",
+				"command": "get_access_code"
+		}
+}
+```
+
+**Report**
+
+```json
+{
+		"system": {
+				"sequence_id": "0",
+				"command": "get_access_code",
+				"access_code": "{ACCESS_CODE}",
+				"result": "success"
+		}
+}
+```
+
 ## camera.ipcam_record_set
 
 Turns on or off creating a recording of prints.

--- a/mqtt.md
+++ b/mqtt.md
@@ -843,10 +843,10 @@ Gets the LAN access code of the printer
 **Request**
 ```json
 {
-		"system": {
-				"sequence_id": "0",
-				"command": "get_access_code"
-		}
+    "system": {
+        "sequence_id": "0",
+        "command": "get_access_code"
+    }
 }
 ```
 
@@ -854,12 +854,12 @@ Gets the LAN access code of the printer
 
 ```json
 {
-		"system": {
-				"sequence_id": "0",
-				"command": "get_access_code",
-				"access_code": "{ACCESS_CODE}",
-				"result": "success"
-		}
+    "system": {
+        "sequence_id": "0",
+        "command": "get_access_code",
+        "access_code": "{ACCESS_CODE}",
+        "result": "success"
+    }
 }
 ```
 


### PR DESCRIPTION
Pretty much self explanatory. Just found this in the source code so might as well add it to public knowledge.