### PR TITLE
Add /design-user-service/my/preference endpoint

### DIFF
--- a/cloud-http.md
+++ b/cloud-http.md
@@ -25,14 +25,14 @@ Either login with password OR verification code, not both
 
 **Response**
 
-Here you grab the `token` and `refreshToken` from the body of the response. They're usually valid for a year.
+Here you grab the `accessToken` and `refreshToken` from the body of the response. They're usually valid for about 3 months.
 ```json
 {
-	"token": "[REMOVED]",
-	"refreshToken": "[REMOVED]",
+	"accessToken": "[REMOVED]",
+	"refreshToken": "[REMOVED]", // same as token
 	"loginType": "", // if empty there should be token, if 'verifyCode' you'll need to use verification code to login
-	"expiresIn": 31536000, // 1 Year in seconds
-	... // and a few other umimportant stuff
+	"expiresIn": 7776000, // ~ 3 Months in seconds
+	... // and a few other unimportant stuff
 }
 ```
 
@@ -154,6 +154,29 @@ Send a valid `refreshToken` and get new tokens with new expiration times.
 	"refreshToken": "[REMOVED]",
 	"expiresIn": 29501294,
 	"refreshExpiresIn": 29501294
+}
+```
+
+## GET /v1/design-user-service/my/preference
+
+Fetches your user account preferences and information. Also is a mirror for `https://makerworld.com/api/v1/design-user-service/my/preference`
+
+Useful for numeric `uid`, which when prefixed with `u_` acts as your cloud mqtt username, as this is no longer provided within access tokens.
+
+**Response**
+```json
+{
+    "uid": 0000000000, // [REMOVED]
+    "name": "name", // [REMOVED]
+    "handle": "handle", // [REMOVED]
+    "avatar": "url", // [REMOVED]
+    "bio": "",
+    "links": [
+        "url1", // [REMOVED]
+        "url2" // [REMOVED]
+    ],
+    "backgroundUrl": "url", // [REMOVED]
+    ... // various unimportant account settings and values, all 0 or 1 for values
 }
 ```
 


### PR DESCRIPTION
Due to recent changes with the access token from signing in (both the email verification, and now being unable to extract expiry time and uid from accessToken), I had looked around for alternative ways to get a user's uid for mqtt cloud login.

Found design-user-service endpoint after some trial and error, and when passed the bearer auth, it will reliable give the uid and some other account values. Also mirrors a makerworld api.

Also updated the signin response, as tokens are now ~3 months lived.

Note: It seems refresh token functionality is no longer a thing. Past few weeks, endpoint always provides an error, and new access tokens are the *same* as the refresh tokens.