### PR TITLE
Document more commands

### DIFF
--- a/mqtt.md
+++ b/mqtt.md
@@ -839,6 +839,26 @@ Updates [`pushing.pushall`](#pushingpushall) with
     ],
 ```
 
+## print.print_option
+
+Modifies the printer's settings.
+
+**Request**
+```json
+{
+  "print": {
+    "sequence_id": "0",
+    "command": "print_option",
+    "auto_recovery": true // can be "auto_recovery", "air_print_detect", "filament_tangle_detect", "nozzle_blob_detect", or "sound_enable"
+  }
+}
+
+```
+
+**Report**
+
+See basic structure
+
 ## system.ledctrl
 
 Controls the LEDs of the printer.
@@ -946,7 +966,7 @@ Configures the XCam (camera AI features, including Micro LIDAR features).
     "xcam": {
         "sequence_id": "0",
         "command": "xcam_control_set",
-        "module_name": "first_layer_inspector", // "first_layer_inspector" or "spaghetti_detector"
+        "module_name": "first_layer_inspector", // "first_layer_inspector", "buildplate_marker_detector", "printing_monitor", "pileup_detector", "airprint_detector", "clump_detector", or "spaghetti_detector"
         "control": true, // Enable the module
         "print_halt": false // Cause the module to halt the print on error
     }

--- a/mqtt.md
+++ b/mqtt.md
@@ -914,6 +914,22 @@ Gets the LAN access code of the printer
 }
 ```
 
+## system.set_accessories.nozzle
+
+Update the nozzle type and diameter.
+
+```json
+{
+    "system": {
+        "sequence_id": "0",
+        "accessory_type": "nozzle",
+        "command": "set_accessories",
+        "nozzle_diameter": 0.4,
+        "nozzle_type": "stainless_steel" // "stainless_steel" or "hardened_steel"
+    }
+}
+```
+
 ## camera.ipcam_record_set
 
 Turns on or off creating a recording of prints.

--- a/mqtt.md
+++ b/mqtt.md
@@ -735,13 +735,21 @@ Starts calibration process.
 
 **Note:** Some printers might need `gcode_file` with `/usr/etc/print/auto_cali_for_user.gcode` instead!
 
+**Note:** The options parameter should be a bitmask like this:
+```
+ if (bedLevelling) bitmask |= 1 << 1;
+ if (vibrationCompensation) bitmask |= 1 << 2;
+ if (motorCancellation) bitmask |= 1 << 3;
+```
+
 **Request**
 
 ```json
 {
     "print": {
         "sequence_id": "0",
-        "command": "calibration"
+        "command": "calibration",
+        "option": 0,
     }
 }
 ```


### PR DESCRIPTION
- Document the print_option command, used for changing printer settings like nozzle clumping detection, filament tangle detection, etc.
- Update the xcam documentation to have more commands
- Document the set_accessories command, used for changing the nozzle type and diameter (a previous pr claims it also can change the state of the enclosure of P1P, but I don't have one to test this)
- Fix the documentation of the calibration command - added documentation for the required "option" parameter, which is a bitmask that tells which calibrations to perform.