### PR TITLE
Add P2S to video.md

### DIFF
--- a/video.md
+++ b/video.md
@@ -1,8 +1,8 @@
 # Basics
 
-## X1
+## X1 and P2S
 
-The X1 series printers run a RTSP server that streams video over the network.
+The X1 series and P2S printers run a RTSP server that streams video over the network.
 
 ### Local RTSP Server
 


### PR DESCRIPTION
Added P2S to the docs, since P2S printers also work in the same way as the X1 series printers in terms of video stream - they also broadcast RTSP stream.