### PR TITLE
docs(mqtt): cert_id appears to be the leaf cert serial number, not MD5

### DIFF
--- a/cloud-x509-auth.md
+++ b/cloud-x509-auth.md
@@ -101,7 +101,7 @@ The `cert_id` format is:
 ```
 
 Where:
-- `hex_fingerprint` is a 32-char lowercase hex string. In the envelopes I
+- `hex_fingerprint` is a 32-char lowercase hex string. In captured envelopes
   captured this matched the leaf certificate's
   `tbsCertificate.serialNumber` rather than an MD5 over the cert. You can
   check against your own capture with:

--- a/cloud-x509-auth.md
+++ b/cloud-x509-auth.md
@@ -101,7 +101,16 @@ The `cert_id` format is:
 ```
 
 Where:
-- `hex_fingerprint` is a 32-char hex string (MD5 of the certificate)
+- `hex_fingerprint` is a 32-char lowercase hex string. In the envelopes I
+  captured this matched the leaf certificate's
+  `tbsCertificate.serialNumber` rather than an MD5 over the cert. You can
+  check against your own capture with:
+
+  ```sh
+  # leaf.pem = the cert the client presented for this session
+  openssl x509 -in leaf.pem -serial -noout
+  # → the hex value should match the cert_id prefix (before any CN= suffix)
+  ```
 - `serialNumber` is the printer's serial number (e.g., `GLOF3813734089`)
 
 ## Signing Details


### PR DESCRIPTION
Hi! Spotted this while building a small MQTT client against the protocol.

The `cert_id` field in the envelope header looks like the leaf cert's `tbsCertificate.serialNumber` rendered as a lowercase 32-char hex string (often with a `CN=...` suffix when the client composes a per-instance id), rather than an MD5 over the cert. In every envelope I captured, the prefix exactly matched `openssl x509 -in leaf.pem -serial -noout` from the leaf presented during the TLS handshake.

Anyone can verify with:

```sh
# Given a leaf.pem extracted from the cert exchange / envelope
openssl x509 -in leaf.pem -serial -noout
# -> matches the cert_id prefix in the envelope header (before any CN= suffix)
```

I might be misreading the format - happy to update or close this if so. Thanks for maintaining these docs; they're a great reference!
