### PR TITLE
docs(video): H2 series — same RTSPS URL, default-off

### DIFF
--- a/video.md
+++ b/video.md
@@ -12,6 +12,29 @@ The X1 series and P2S printers run a RTSP server that streams video over the net
 - **Username**: `bblp`
 - **Password**: `dev_access_code` from a `Device` object (aka the LAN access code).
 
+## H2 series
+
+H2S and H2D printers also serve the same `rtsps://{PRINTER_IP}:322/streaming/live/1`
+RTSPS feed, but on the firmwares observed (H2S `01.02.00.00`, H2D
+`01.02.00.00`) the LAN-RTSPS server appears to be **off by default**:
+port 322 closes the TCP connection immediately and the printer's
+`push_status` reports `ipcam.rtsp_url = "disable"`.
+
+To enable it, on the printer's touchscreen:
+
+1. Settings → General → LAN Mode Liveview (label varies by firmware track)
+2. Toggle "LAN Only Liveview" / "Local RTSP Stream" to on.
+
+After the toggle, `push_status` reports `ipcam.rtsp_url =
+"rtsps://{PRINTER_IP}:322/streaming/live/1"` and the port begins
+accepting connections. The same `bblp` + `dev_access_code` credentials
+apply.
+
+If the local toggle is left off, the printer is still reachable via
+the proprietary cloud-relay transports (TUTK / Agora P2P) and the
+slicer's MediaPlayCtrl path falls through to those automatically; only
+the direct `rtsps://` URL is gated.
+
 ## A1 and P1
 
 The A1 and P1 series printers run a simple TCP server that streams 1280x720 JPEG images over the network.


### PR DESCRIPTION
A short addition under `## H2 series` in `video.md`.

H2S and H2D firmware tracks observed (both `01.02.00.00`) serve the
same `rtsps://{PRINTER_IP}:322/streaming/live/1` RTSPS feed as X1/P2S,
but the LAN-RTSPS server appears to be **off by default**:

- Port 322 closes the TCP connection immediately on connect.
- `push_status` reports `ipcam.rtsp_url = "disable"`.

A user-facing toggle on the printer's touchscreen (Settings → General
→ LAN Mode Liveview, label varies by firmware track) flips this — once
enabled, `push_status` switches to the full
`rtsps://{PRINTER_IP}:322/streaming/live/1` value and the port begins
accepting connections.

This trips up clients implementing the existing `video.md` flow
against an H2 printer that hasn't had the toggle flipped — port 322 is
closed but the printer is otherwise reachable. The new section
documents the toggle, the resulting `push_status` value, and notes
that the cloud-relay transports remain available regardless.

Scoped explicitly to H2S `01.02.00.00` and H2D `01.02.00.00` since
that's what was actually observed; behaviour on other H2 firmwares
hasn't been checked.

Happy to scope down, split, or drop bits if the toggle exists across
all H2 firmwares or the default is build-dependent.